### PR TITLE
Windows: Unblock esy postinstall on Windows

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -13,6 +13,10 @@ case $(uname) in
   Linux*)
     mv esySolveCudfCommandLinux.exe "$TARGET"
     ;;
+  CYGWIN*|MSYS*)
+    echo "TODO: Add support for Windows"
+    exit 0
+    ;;
   *)
     echo "Unsupported operating system $(uname), exiting...";
     exit 1


### PR DESCRIPTION
__Issue:__ Bootstrapping the Windows build of `esy` is blocked today due to `postinstall` failure here.

__Defect:__ When `esy` is installing dependencies, the `postinstall.sh` script here is run, and it exits with code 1 on non-mac or linux platforms.

__Fix:__ For now, just suppress this error - for the bootstrapped windows build, we're not building `esyi` yet, so we actually don't need `esy-solve-cudf` at the moment. However, there isn't a way to conditionally include a dependency based on platform (at least, that I'm aware of), so for now I just made the postinstall step a no-op.

Let me know if you have other ideas or another fix you'd prefer, @andreypopp !