### PR TITLE
Add support for FreeBSD, NetBSD, OpenBSD 

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -11,16 +11,19 @@ const install = (filename) => {
 }
 
 switch (platform) {
+  default:
+    console.warn('[esy-solve-cudf] Unsupported operating system; dependent commands may not function correctly')
+    // assume a UNIX-like system and fall-through
   case 'linux':
   case 'darwin':
+  case 'freebsd':
+  case 'netbsd':
+  case 'openbsd':
     install('esySolveCudfCommand.exe');
     fs.chmodSync(path.join(__dirname, 'esySolveCudfCommand.exe'), 0755);
     break;
   case 'win32':
     install('esySolveCudfCommand.exe');
     // chmod doesn't make sense on win32
-    break;
-  default:
-    console.warn('[esy-solve-cudf] Unsupported operating system; dependent commands may not function correctly')
     break;
 }


### PR DESCRIPTION
Added postinstall.js case statements for free/net/openbsd; additionally, if the os.platform is unrecognized, assume a UNIX-like system.

Should resolve #12